### PR TITLE
Edit Multiupload Description

### DIFF
--- a/pgutil/Assets/UploadCommand.cs
+++ b/pgutil/Assets/UploadCommand.cs
@@ -96,7 +96,7 @@ internal partial class Program
             {
                 public static bool Required => false;
                 public static string Name => "--partsize";
-                public static string Description => "Chunk size (in mb) for multipart uploads";
+                public static string Description => "Part size (in mb) for multipart uploads";
                 public static string DefaultValue => "5";
             }
 


### PR DESCRIPTION
Changed "chunk" to "part" in line with how multipart uploads are talked about in docs. "Chunk" is never used elsewhere it seems.