### PR TITLE
Url and Example Fixes

### DIFF
--- a/pgutil/ApiKeys/Create/FeedCommand.cs
+++ b/pgutil/ApiKeys/Create/FeedCommand.cs
@@ -20,7 +20,7 @@ internal partial class Program
 
                       $> pgutil apikeys create feed --group=production-feeds --key=wxyz67890 --expiration="2024/08/01"
 
-                    For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-apikeys/proget-api-apikeys-create
+                    For more information, see: https://docs.inedo.com/docs/proget/api/apikeys/create
                     """;
 
                 public static void Configure(ICommandBuilder builder)

--- a/pgutil/ApiKeys/Create/PersonalCommand.cs
+++ b/pgutil/ApiKeys/Create/PersonalCommand.cs
@@ -20,7 +20,7 @@ internal partial class Program
 
                       $> pgutil apikeys create personal --user=mikejones --name="Mike Jones" --description="API key for Mike Jones"
 
-                    For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-apikeys/proget-api-apikeys-create
+                    For more information, see: https://docs.inedo.com/docs/proget/api/apikeys/create
                     """;
 
                 public static void Configure(ICommandBuilder builder)

--- a/pgutil/ApiKeys/Create/SystemCommand.cs
+++ b/pgutil/ApiKeys/Create/SystemCommand.cs
@@ -18,7 +18,7 @@ internal partial class Program
 
                       $> pgutil apikeys create system --apis="feeds" --key=feeds12345 --logging=both --name="Feeds Key" 
 
-                    For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-apikeys/proget-api-apikeys-create
+                    For more information, see: https://docs.inedo.com/docs/proget/api/apikeys/create
                     """;
 
                 public static void Configure(ICommandBuilder builder)

--- a/pgutil/ApiKeys/DeleteCommand.cs
+++ b/pgutil/ApiKeys/DeleteCommand.cs
@@ -13,7 +13,7 @@ internal partial class Program
             public static string Examples => """
                   $> pgutil apikeys delete --id=43
 
-                For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-apikeys/proget-api-apikeys-delete
+                For more information, see: https://docs.inedo.com/docs/proget/api/apikeys/delete
                 """;
 
             public static void Configure(ICommandBuilder builder)

--- a/pgutil/Assets/DeleteCommand.cs
+++ b/pgutil/Assets/DeleteCommand.cs
@@ -18,8 +18,8 @@ internal partial class Program
                   $> pgutil assets delete --feed=test-assets --path=test-files --force
 
                 For more information, see:
-                  * https://docs.inedo.com/docs/proget/reference-api/proget-api-assets/file-endpoints/proget-api-assets-files-delete
-                  * https://docs.inedo.com/docs/proget/reference-api/proget-api-assets/folder-endpoints/proget-api-assets-folders-delete
+                  * https://docs.inedo.com/docs/proget/api/assets/files/delete
+                  * https://docs.inedo.com/docs/proget/api/assets/folders/delete
                 """;
 
             public static void Configure(ICommandBuilder builder)

--- a/pgutil/Assets/DownloadCommand.cs
+++ b/pgutil/Assets/DownloadCommand.cs
@@ -13,7 +13,7 @@ internal partial class Program
             public static string Examples => """
                   $> pgutil assets download --feed=development-assets --path=test-files/info.txt --output=C:\Inedo\test-files
 
-                For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-assets/file-endpoints/proget-api-assets-files-download
+                For more information, see: https://docs.inedo.com/docs/proget/api/assets/files/download
                 """;
 
             public static void Configure(ICommandBuilder builder)

--- a/pgutil/Assets/Folder/CreateCommand.cs
+++ b/pgutil/Assets/Folder/CreateCommand.cs
@@ -15,7 +15,7 @@ internal partial class Program
                 public static string Examples => """
                       $> pgutil assets folder create --feed=development-assets --path=test-packages
 
-                    For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-assets/folder-endpoints/proget-api-assets-folders-create
+                    For more information, see: https://docs.inedo.com/docs/proget/api/assets/folders/create
                     """;
 
                 public static void Configure(ICommandBuilder builder)

--- a/pgutil/Assets/Folder/ExportCommand.cs
+++ b/pgutil/Assets/Folder/ExportCommand.cs
@@ -16,7 +16,7 @@ internal partial class Program
                 public static string Examples => """
                       $> pgutil assets folder export --file=C:\Inedo\production-packages.zip --feed=production-assets --path=production-files
 
-                    For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-assets/folder-endpoints/proget-api-assets-folders-export
+                    For more information, see: https://docs.inedo.com/docs/proget/api/assets/folders/-export
                     """;
 
                 public static void Configure(ICommandBuilder builder)

--- a/pgutil/Assets/Folder/ImportCommand.cs
+++ b/pgutil/Assets/Folder/ImportCommand.cs
@@ -16,7 +16,7 @@ internal partial class Program
                 public static string Examples => """
                       $> pgutil assets folder import --file=C:\Inedo\data-files\test-files.zip --path=test-files --feed=development-assets
 
-                    For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-assets/folder-endpoints/proget-api-assets-folders-import
+                    For more information, see: https://docs.inedo.com/docs/proget/api/assets/folders/import
                     """;
 
                 public static void Configure(ICommandBuilder builder)

--- a/pgutil/Assets/ListCommand.cs
+++ b/pgutil/Assets/ListCommand.cs
@@ -13,7 +13,7 @@ internal partial class Program
             public static string Examples => """
                   $> pgutil assets list --feed=development-assets
 
-                For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-assets/folder-endpoints/proget-api-assets-folders-list
+                For more information, see: https://docs.inedo.com/docs/proget/api/assets/folders/list
                 """;
 
             public static void Configure(ICommandBuilder builder)

--- a/pgutil/Assets/Metadata/GetCommand.cs
+++ b/pgutil/Assets/Metadata/GetCommand.cs
@@ -15,7 +15,7 @@ internal partial class Program
                 public static string Examples => """
                       $> pgutil assets metadata get --path=data-files/data.bin --feed=development-assets
 
-                    For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-assets/metadata-endpoints/proget-api-assets-metadata-get
+                    For more information, see: https://docs.inedo.com/docs/proget/api/assets/metadata/get
                     """;
 
                 public static void Configure(ICommandBuilder builder)

--- a/pgutil/Assets/Metadata/SetCommand.cs
+++ b/pgutil/Assets/Metadata/SetCommand.cs
@@ -27,9 +27,7 @@ internal partial class Program
                     public static string Examples => """
                           $> pgutil assets metadata set custom --path=data-files/data.bin --feed=development-assets --key=project-name --value=project-alpha
 
-                          $> pgutil assets metadata set cache --path=project-files/data.bin --feed=production-assets --type=TTL --value=60
-
-                        For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-assets/metadata-endpoints/proget-api-assets-metadata-set
+                        For more information, see: https://docs.inedo.com/docs/proget/api/assets/metadata/set
                         """;
 
                     public static void Configure(ICommandBuilder builder)
@@ -86,6 +84,11 @@ internal partial class Program
                 {
                     public static string Name => "cache";
                     public static string Description => "Sets the cache header";
+                    public static string Examples => """
+                          $> pgutil assets metadata set cache --path=project-files/data.bin --feed=production-assets --type=TTL --value=60
+
+                        For more information, see: https://docs.inedo.com/docs/proget/api/assets/metadata/set
+                        """;
 
                     public static void Configure(ICommandBuilder builder)
                     {

--- a/pgutil/Assets/UploadCommand.cs
+++ b/pgutil/Assets/UploadCommand.cs
@@ -13,7 +13,7 @@ internal partial class Program
             public static string Examples => """
                   $> pgutil assets upload --feed=production-assets --target-path=uploaded-files/download-stats.txt --file=C:\Inedo\data-files\download-stats.txt
 
-                For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-assets/file-endpoints/proget-api-assets-files-upload
+                For more information, see: https://docs.inedo.com/docs/proget/api/assets/files/upload
                 """;
 
             public static void Configure(ICommandBuilder builder)

--- a/pgutil/Builds/AuditCommand.cs
+++ b/pgutil/Builds/AuditCommand.cs
@@ -16,7 +16,7 @@ internal partial class Program
             public static string Examples => """
                   >$ pgutil builds audit --build=1.2.0 --project=testApplication
 
-                For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-sca/builds/proget-api-sca-builds-analyze
+                For more information, see: https://docs.inedo.com/docs/proget/api/sca/builds/analyze
                 """;
 
             public static void Configure(ICommandBuilder builder)

--- a/pgutil/Builds/BuildsCommand.cs
+++ b/pgutil/Builds/BuildsCommand.cs
@@ -8,11 +8,6 @@ internal partial class Program
     {
         public static string Name => "builds";
         public static string Description => "Manages SCA builds and SBOM documents";
-        public static string Examples => """
-              >$ pgutil builds create --build=1.0.0 --project=testApplication
-
-            For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-sca/builds/proget-api-sca-builds-create
-            """;
 
         public static void Configure(ICommandBuilder builder)
         {

--- a/pgutil/Builds/Comments/CreateCommand.cs
+++ b/pgutil/Builds/Comments/CreateCommand.cs
@@ -16,7 +16,7 @@ internal partial class Program
                 public static string Examples => """
                       >$ pgutil builds comments create --project=newApplication --build=1.0.1 --comment="Checked for errors on 01/01"
 
-                    For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-sca/comments/proget-api-sca-comments-create
+                    For more information, see: https://docs.inedo.com/docs/proget/api/sca/comments/create
                     """;
 
                 public static void Configure(ICommandBuilder builder)

--- a/pgutil/Builds/Comments/DeleteCommand.cs
+++ b/pgutil/Builds/Comments/DeleteCommand.cs
@@ -15,7 +15,7 @@ internal partial class Program
                 public static string Examples => """
                       >$ pgutil builds comments delete --project=myProject --build=1.2.3 --number=4
 
-                    For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-sca/issues/proget-api-sca-comments-delete
+                    For more information, see: https://docs.inedo.com/docs/proget/api/sca/comments/delete
                     """;
 
                 public static void Configure(ICommandBuilder builder)

--- a/pgutil/Builds/Comments/ListCommand.cs
+++ b/pgutil/Builds/Comments/ListCommand.cs
@@ -15,7 +15,7 @@ internal partial class Program
                 public static string Examples => """
                       >$ pgutil builds comments list --project=testProject --build=2.2.4
 
-                    For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-sca/issues/proget-api-sca-comments-list
+                    For more information, see: https://docs.inedo.com/docs/proget/api/sca/comments/list
                     """;
 
                 public static void Configure(ICommandBuilder builder)

--- a/pgutil/Builds/CreateCommand.cs
+++ b/pgutil/Builds/CreateCommand.cs
@@ -11,13 +11,9 @@ internal partial class Program
             public static string Name => "create";
             public static string Description => "Creates a build";
             public static string Examples => """
-                  >$ pgutil builds projects create --project=newProject
-                
-                  >$ pgutil builds projects create --project=newApplication --type=Application
-                
-                  >$ pgutil builds projects create --project=testApplication --type=Application --url=https://proget.corp.local
+                >$ pgutil builds create --build=1.0.0 --project=testApplication
 
-                For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-sca/projects/proget-api-sca-projects-create
+                For more information, see: https://docs.inedo.com/docs/proget/api/sca/builds/create
                 """;
 
             public static void Configure(ICommandBuilder builder)

--- a/pgutil/Builds/InfoCommand.cs
+++ b/pgutil/Builds/InfoCommand.cs
@@ -13,7 +13,7 @@ internal partial class Program
             public static string Examples => """
                   >$ pgutil builds info --build=4.5.0 --project=newApplication
 
-                For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-sca/builds/proget-api-sca-builds-get
+                For more information, see: https://docs.inedo.com/docs/proget/api/sca/builds/get
                 """;
 
             public static void Configure(ICommandBuilder builder)

--- a/pgutil/Builds/Issues/DeleteCommand.cs
+++ b/pgutil/Builds/Issues/DeleteCommand.cs
@@ -15,7 +15,7 @@ internal partial class Program
                 public static string Examples => """
                       >$ pgutil builds issues delete --project=myProject --build=1.2.3 --number=4
 
-                    For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-sca/issues/proget-api-sca-issues-delete
+                    For more information, see: https://docs.inedo.com/docs/proget/api/sca/issues/delete
                     """;
 
                 public static void Configure(ICommandBuilder builder)

--- a/pgutil/Builds/Issues/ListCommand.cs
+++ b/pgutil/Builds/Issues/ListCommand.cs
@@ -15,7 +15,7 @@ internal partial class Program
                 public static string Examples => """
                       >$ pgutil builds issues list --project=testApplication --build=1.2.0
 
-                    For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-sca/issues/proget-api-sca-issues-list
+                    For more information, see: https://docs.inedo.com/docs/proget/api/sca/issues/list
                     """;
 
                 public static void Configure(ICommandBuilder builder)

--- a/pgutil/Builds/Issues/ResolveCommand.cs
+++ b/pgutil/Builds/Issues/ResolveCommand.cs
@@ -15,7 +15,7 @@ internal partial class Program
                 public static string Examples => """
                       >$ pgutil builds issues resolve --project=newApplication --build=1.0.1 --number=2
 
-                    For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-sca/issues/proget-api-sca-issues-resolve
+                    For more information, see: https://docs.inedo.com/docs/proget/api/sca/issues/resolve
                     """;
 
                 public static void Configure(ICommandBuilder builder)

--- a/pgutil/Builds/ListCommand.cs
+++ b/pgutil/Builds/ListCommand.cs
@@ -13,7 +13,7 @@ internal partial class Program
             public static string Examples => """
                   >$ pgutil builds list --project=newApplication
 
-                For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-sca/builds/proget-api-sca-builds-list
+                For more information, see: https://docs.inedo.com/docs/proget/api/sca/builds/list
                 """;
 
             public static void Configure(ICommandBuilder builder)

--- a/pgutil/Builds/Projects/CreateCommand.cs
+++ b/pgutil/Builds/Projects/CreateCommand.cs
@@ -13,7 +13,15 @@ internal partial class Program
             {
                 public static string Name => "create";
                 public static string Description => "Creates or updates project information";
+                public static string Examples => """
+                    >$ pgutil builds projects create --project=newProject
+                    
+                    >$ pgutil builds projects create --project=newApplication --type=Application
+                    
+                    >$ pgutil builds projects create --project=testApplication --type=Application --url=https://proget.corp.local
 
+                    For more information, see: https://docs.inedo.com/docs/proget/api/sca/projects/create
+                    """;
                 public static void Configure(ICommandBuilder builder)
                 {
                     builder.WithOption<ProjectOption>()

--- a/pgutil/Builds/PromoteCommand.cs
+++ b/pgutil/Builds/PromoteCommand.cs
@@ -13,7 +13,7 @@ internal partial class Program
             public static string Examples => """
                   $> pgutil builds promote --project=DataApplication --build=1.0.2 --stage=Test
 
-                For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-sca/builds/proget-api-sca-builds-list.md
+                For more information, see: https://docs.inedo.com/docs/proget/api/sca/builds/promote
                 """;
 
             public static void Configure(ICommandBuilder builder)

--- a/pgutil/Builds/SbomCommand.cs
+++ b/pgutil/Builds/SbomCommand.cs
@@ -15,7 +15,7 @@ internal partial class Program
             public static string Examples => """
                   $> pgutil builds sbom --input=WebApplicationTool.csproj --output=C:\pgutil\output.xml --project-name="Web Application Tool" --version=1.2.3 
 
-                For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-sca/sbom/proget-api-sca-sbom-export
+                For more information, see: https://docs.inedo.com/docs/proget/api/sca/sbom/export
                 """;
 
             public static void Configure(ICommandBuilder builder)

--- a/pgutil/Builds/ScanCommand.cs
+++ b/pgutil/Builds/ScanCommand.cs
@@ -17,7 +17,7 @@ internal partial class Program
             public static string Examples => """
                   $> pgutil builds scan --project-name="Web Data Tool" --version=1.2.3
 
-                For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-sca/builds/proget-api-sca-builds-scan
+                For more information, see: https://docs.inedo.com/docs/proget/api/sca/builds/scan
                 """;
 
             public static void Configure(ICommandBuilder builder)

--- a/pgutil/Connectors/CreateCommand.cs
+++ b/pgutil/Connectors/CreateCommand.cs
@@ -14,7 +14,7 @@ internal sealed partial class Program
             public static string Examples => """
                   $> pgutil connectors create --name=nuget.org --type=NuGet --url=https://nuget.org
 
-                For more information, see: https://docs.inedo.com/docs/proget/reference-api/feeds/proget-api-connectors/proget-api-connectors-create
+                For more information, see: https://docs.inedo.com/docs/proget/reference-api/connectors/create
                 """;
 
             public static void Configure(ICommandBuilder builder)

--- a/pgutil/Connectors/DeleteCommand.cs
+++ b/pgutil/Connectors/DeleteCommand.cs
@@ -13,7 +13,7 @@ internal sealed partial class Program
             public static string Examples => """
                   $> pgutil connectors delete --connector=nuget.org
 
-                For more information, see: https://docs.inedo.com/docs/proget/reference-api/feeds/proget-api-connectors/proget-api-connectors-delete
+                For more information, see: https://docs.inedo.com/docs/proget/api/connectors/delete
                 """;
 
             public static void Configure(ICommandBuilder builder)

--- a/pgutil/Connectors/Filters/AddCommand.cs
+++ b/pgutil/Connectors/Filters/AddCommand.cs
@@ -17,7 +17,7 @@ internal sealed partial class Program
 
                       $> pgutil connectors filters add --connector=registry.npmjs.org --filter=Microsoft.*
 
-                    For more information, see: https://docs.inedo.com/docs/proget/reference-api/feeds/proget-api-connectors/proget-api-connectors-update
+                    For more information, see: https://docs.inedo.com/docs/proget/api/connectors/update
                     """;
 
                 public static void Configure(ICommandBuilder builder)

--- a/pgutil/Connectors/Filters/ListCommand.cs
+++ b/pgutil/Connectors/Filters/ListCommand.cs
@@ -15,7 +15,7 @@ internal sealed partial class Program
                 public static string Examples => """
                       $> pgutil connectors filters list --connector=nuget.org
 
-                    For more information, see: https://docs.inedo.com/docs/proget/reference-api/feeds/proget-api-connectors/proget-api-connectors-update
+                    For more information, see: https://docs.inedo.com/docs/proget/api/connectors/update
                     """;
 
                 public static void Configure(ICommandBuilder builder)

--- a/pgutil/Connectors/Filters/RemoveCommand.cs
+++ b/pgutil/Connectors/Filters/RemoveCommand.cs
@@ -17,7 +17,7 @@ internal sealed partial class Program
 
                       $> pgutil connectors filters remove --connector=registry.npmjs.org --filter=Microsoft.*
 
-                    For more information, see: https://docs.inedo.com/docs/proget/reference-api/feeds/proget-api-connectors/proget-api-connectors-update
+                    For more information, see: https://docs.inedo.com/docs/proget/api/connectors/update
                     """;
 
                 public static void Configure(ICommandBuilder builder)

--- a/pgutil/Connectors/Properties/ListCommand.cs
+++ b/pgutil/Connectors/Properties/ListCommand.cs
@@ -15,7 +15,7 @@ internal sealed partial class Program
                 public static string Examples => """
                       $> pgutil connectors properties list --connector=nuget.org
 
-                    For more information, see: https://docs.inedo.com/docs/proget/reference-api/feeds/proget-api-connectors/proget-api-connectors-get
+                    For more information, see: https://docs.inedo.com/docs/proget/api/connectors/get
                     """;
 
                 public static void Configure(ICommandBuilder builder)

--- a/pgutil/Connectors/Properties/SetCommand.cs
+++ b/pgutil/Connectors/Properties/SetCommand.cs
@@ -17,7 +17,7 @@ internal sealed partial class Program
 
                       $> pgutil connectors properties set --connector=registry.npmjs.org --property=timeout --value=30
 
-                    For more information, see: https://docs.inedo.com/docs/proget/reference-api/feeds/proget-api-connectors/proget-api-connectors-update
+                    For more information, see: https://docs.inedo.com/docs/proget/api/feeds/connectors/update
                     """;
 
                 public static void Configure(ICommandBuilder builder)

--- a/pgutil/Feeds/CreateCommand.cs
+++ b/pgutil/Feeds/CreateCommand.cs
@@ -13,7 +13,7 @@ internal sealed partial class Program
             public static string Examples => """
                   $> pgutil feeds create --name=public-nuget --type=NuGet
 
-                For more information, see: https://docs.inedo.com/docs/proget/reference-api/feeds/proget-api-feeds/proget-api-feeds-create
+                For more information, see: https://docs.inedo.com/docs/proget/api/feeds/create
                 """;
 
             public static void Configure(ICommandBuilder builder)

--- a/pgutil/Feeds/DeleteCommand.cs
+++ b/pgutil/Feeds/DeleteCommand.cs
@@ -11,9 +11,9 @@ internal sealed partial class Program
             public static string Name => "delete";
             public static string Description => "Deletes a feed";
             public static string Examples => """
-                  $> pgutil feeds create --name=public-npm
+                  $> pgutil feeds delete --name=public-npm
 
-                For more information, see: https://docs.inedo.com/docs/proget/reference-api/feeds/proget-api-feeds/proget-api-feeds-delete
+                For more information, see: https://docs.inedo.com/docs/proget/api/feeds/delete
                 """;
 
             public static void Configure(ICommandBuilder builder)

--- a/pgutil/Feeds/ListCommand.cs
+++ b/pgutil/Feeds/ListCommand.cs
@@ -15,7 +15,7 @@ internal sealed partial class Program
 
                   $> pgutil feeds list --inactive
 
-                For more information, see: https://docs.inedo.com/docs/proget/reference-api/feeds/proget-api-feeds/proget-api-feeds-list
+                For more information, see: https://docs.inedo.com/docs/proget/api/feedsfeeds/list
                 """;
 
             public static void Configure(ICommandBuilder builder)

--- a/pgutil/Feeds/Properties/ListCommand.cs
+++ b/pgutil/Feeds/Properties/ListCommand.cs
@@ -15,7 +15,7 @@ internal sealed partial class Program
                 public static string Examples => """
                       $> pgutil feeds properties list --feed=myNugetFeed
 
-                    For more information, see: https://docs.inedo.com/docs/proget/reference-api/feeds/proget-api-feeds/proget-api-feeds-get
+                    For more information, see: https://docs.inedo.com/docs/proget/api/feeds/get
                     """;
 
                 public static void Configure(ICommandBuilder builder)

--- a/pgutil/Feeds/Properties/SetCommand.cs
+++ b/pgutil/Feeds/Properties/SetCommand.cs
@@ -20,7 +20,7 @@ internal sealed partial class Program
 
                       $> pgutil feeds properties set --feed=public-pypi --property=active --value=false
 
-                    For more information, see: https://docs.inedo.com/docs/proget/reference-api/feeds/proget-api-feeds/proget-api-feeds-update
+                    For more information, see: https://docs.inedo.com/docs/proget/api/feeds/update
                     """;
 
                 public static void Configure(ICommandBuilder builder)

--- a/pgutil/Feeds/Retention/CreateCommand.cs
+++ b/pgutil/Feeds/Retention/CreateCommand.cs
@@ -16,11 +16,11 @@ internal sealed partial class Program
                 public static string Examples => """
                       $> pgutil feeds retention create --feed=public-nuget --deletePrereleaseVersions=true
 
-                      $> pgutil feeds retention update --feed=approved-npm --keepUsedWithinDays=30
+                      $> pgutil feeds retention create --feed=approved-npm --keepUsedWithinDays=30
 
-                      $> pgutil feeds retention update --feed=public-pypi --deleteCached=true --keepVersionsCount=5
+                      $> pgutil feeds retention create --feed=public-pypi --deleteCached=true --keepVersionsCount=5
 
-                    For more information, see: https://docs.inedo.com/docs/proget/reference-api/feeds/proget-api-feeds/proget-api-feeds-update
+                    For more information, see: https://docs.inedo.com/docs/proget/api/feeds/update
                     """;
 
                 public static void Configure(ICommandBuilder builder)

--- a/pgutil/Feeds/Retention/DeleteCommand.cs
+++ b/pgutil/Feeds/Retention/DeleteCommand.cs
@@ -15,7 +15,7 @@ internal sealed partial class Program
                 public static string Examples => """
                       $> pgutil feeds retention delete --feed=public-npm --rule=4
 
-                    For more information, see: https://docs.inedo.com/docs/proget/reference-api/feeds/proget-api-feeds/proget-api-feeds-update
+                    For more information, see: https://docs.inedo.com/docs/proget/api/feeds/update
                     """;
 
                 public static void Configure(ICommandBuilder builder)

--- a/pgutil/Feeds/Retention/ListCommand.cs
+++ b/pgutil/Feeds/Retention/ListCommand.cs
@@ -15,7 +15,7 @@ internal sealed partial class Program
                 public static string Examples => """
                       $> pgutil feeds retention list --feed=public-nuget
 
-                    For more information, see: https://docs.inedo.com/docs/proget/reference-api/feeds/proget-api-feeds/proget-api-feeds-update
+                    For more information, see: https://docs.inedo.com/docs/proget/api/feeds/update
                     """;
 
                 public static void Configure(ICommandBuilder builder)

--- a/pgutil/Feeds/Retention/UpdateCommand.cs
+++ b/pgutil/Feeds/Retention/UpdateCommand.cs
@@ -19,7 +19,7 @@ internal sealed partial class Program
 
                       $> pgutil feeds retention update --feed=public-pypi --deleteCached=true --keepVersionsCount=5 --rule=5
 
-                    For more information, see: https://docs.inedo.com/docs/proget/reference-api/feeds/proget-api-feeds/proget-api-feeds-update
+                    For more information, see: https://docs.inedo.com/docs/proget/api/feeds/update
                     """;
 
                 public static void Configure(ICommandBuilder builder)

--- a/pgutil/Feeds/Storage/ChangeCommand.cs
+++ b/pgutil/Feeds/Storage/ChangeCommand.cs
@@ -22,7 +22,7 @@ internal sealed partial class Program
 
                       $> pgutil feeds storage change --feed=approved-npm --type=azure --ConnectionString=DefaultEndpointsProtocol=https;AccountName=myazurestorage;AccountKey=XXXXXXXXXXXXXXXXXXXXX;EndpointSuffix=core.windows.net --ContainerName=projectdocuments --TargetPath=projectdocuments/uploads/2024/07/
 
-                    For more information, see: https://docs.inedo.com/docs/proget/reference-api/feeds/proget-api-feeds/proget-api-feeds-storage-update
+                    For more information, see: https://docs.inedo.com/docs/proget/api/feeds/storage-update
                     """;
 
                 public static void Configure(ICommandBuilder builder)

--- a/pgutil/Feeds/Storage/InfoCommand.cs
+++ b/pgutil/Feeds/Storage/InfoCommand.cs
@@ -15,7 +15,7 @@ internal sealed partial class Program
                 public static string Examples => """
                       $> pgutil feeds storage info --feed=approved-nuget
 
-                    For more information, see: https://docs.inedo.com/docs/proget/reference-api/feeds/proget-api-feeds/proget-api-feeds-storage-get
+                    For more information, see: https://docs.inedo.com/docs/proget/api/feeds/storage-get
                     """;
 
                 public static void Configure(ICommandBuilder builder)

--- a/pgutil/Health/HealthCommand.cs
+++ b/pgutil/Health/HealthCommand.cs
@@ -11,7 +11,7 @@ internal partial class Program
         public static string Examples => """
               $> pgutil health --source=http://progets.corp.local/
 
-            For more information, see: https://docs.inedo.com/docs/proget/reference-api/health
+            For more information, see: https://docs.inedo.com/docs/proget/api/health
             """;
 
         public static void Configure(ICommandBuilder builder)

--- a/pgutil/Licenses/CreateCommand.cs
+++ b/pgutil/Licenses/CreateCommand.cs
@@ -12,9 +12,9 @@ internal partial class Program
             public static string Name => "create";
             public static string Description => "Adds a license definition to ProGet";
             public static string Examples => """
-                  $> pgutil licenses info --code=ABC-1.0 --title="ABC License v1.0"
+                  $> pgutil licenses create --code=ABC-1.0 --title="ABC License v1.0"
 
-                For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-licenses/proget-api-licenses-create
+                For more information, see: https://docs.inedo.com/docs/proget/api/licenses/create
                 """;
 
             public static void Configure(ICommandBuilder builder)

--- a/pgutil/Licenses/DeleteCommand.cs
+++ b/pgutil/Licenses/DeleteCommand.cs
@@ -13,7 +13,7 @@ internal partial class Program
             public static string Examples => """
                   $> pgutil licenses delete --code=GPL-3.0
 
-                For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-licenses/proget-api-licenses-delete
+                For more information, see: https://docs.inedo.com/docs/proget/api/licenses/delete
                 """;
 
             public static void Configure(ICommandBuilder builder)

--- a/pgutil/Licenses/Detection/AddCommand.cs
+++ b/pgutil/Licenses/Detection/AddCommand.cs
@@ -21,7 +21,7 @@ internal partial class Program
 
                       $> pgutil licenses detection add --code=NewLicense --type=url --value=https://proget.corp.local
 
-                    For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-licenses/proget-api-licenses-update
+                    For more information, see: https://docs.inedo.com/docs/proget/api/licenses/update
                     """;
 
                 public static void Configure(ICommandBuilder builder)

--- a/pgutil/Licenses/Detection/RemoveCommand.cs
+++ b/pgutil/Licenses/Detection/RemoveCommand.cs
@@ -20,7 +20,7 @@ internal partial class Program
 
                   $> pgutil licenses detection remove --code=NewLicense --type=url --value=https://proget.corp.local
 
-                For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-licenses/proget-api-licenses-update
+                For more information, see: https://docs.inedo.com/docs/proget/api/licenses/update
                 """;
 
                 public static void Configure(ICommandBuilder builder)

--- a/pgutil/Licenses/Files/AddCommand.cs
+++ b/pgutil/Licenses/Files/AddCommand.cs
@@ -15,7 +15,7 @@ internal partial class Program
                 public static string Examples => """
                       $> pgutil licenses files add --code=ABC-1.0 --file=C:\documents\license-files\abc-1.0-license-file.txt
 
-                    For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-licenses/proget-api-licenses-update
+                    For more information, see: https://docs.inedo.com/docs/proget/api/licenses/update
                     """;
 
                 public static void Configure(ICommandBuilder builder)

--- a/pgutil/Licenses/Files/DeleteCommand.cs
+++ b/pgutil/Licenses/Files/DeleteCommand.cs
@@ -15,7 +15,7 @@ internal partial class Program
                 public static string Examples => """
                       $> pgutil licenses files delete --hash=00462de3d7b6f3e5551a69ae84344bc69d23c02e1353be3e8445d16f025e523b
 
-                    For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-licenses/proget-api-licenses-update
+                    For more information, see: https://docs.inedo.com/docs/proget/api/licenses/update
                     """;
 
                 public static void Configure(ICommandBuilder builder)

--- a/pgutil/Licenses/Files/ShowCommand.cs
+++ b/pgutil/Licenses/Files/ShowCommand.cs
@@ -15,7 +15,7 @@ internal partial class Program
                 public static string Examples => """
                       $> pgutil licenses files show --code=MIT --hash=0630520a7440edc1e05c3f318eba0df31920d5b4ff0848ed10d7922b34eed796
 
-                    For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-licenses/proget-api-licenses-get
+                    For more information, see: https://docs.inedo.com/docs/proget/api/licenses/get
                     """;
 
                 public static void Configure(ICommandBuilder builder)

--- a/pgutil/Licenses/InfoCommand.cs
+++ b/pgutil/Licenses/InfoCommand.cs
@@ -13,7 +13,7 @@ internal partial class Program
             public static string Examples => """
                   $> pgutil licenses info --code=MIT
 
-                For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-licenses/proget-api-licenses-get
+                For more information, see: https://docs.inedo.com/docs/proget/api/licenses/get
                 """;
 
             public static void Configure(ICommandBuilder builder)

--- a/pgutil/Packages/DeleteCommand.cs
+++ b/pgutil/Packages/DeleteCommand.cs
@@ -15,7 +15,7 @@ internal partial class Program
                   $> pgutil packages delete --feed=public-pypi --package=Django --version=5.0.6 --filename=Django-5.0.6.tar.gz
                   $> pgutil packages delete --feed=private-debian --package=debhelper --version=13.15.3 --component=main --distro=stable --arch=all
 
-                For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-packages/proget-api-packages-delete
+                For more information, see: https://docs.inedo.com/docs/proget/api/packages/delete
                 """;
 
             public static void Configure(ICommandBuilder builder) => WithPackageOptions(builder);

--- a/pgutil/Packages/DownloadCommand.cs
+++ b/pgutil/Packages/DownloadCommand.cs
@@ -15,7 +15,7 @@ internal partial class Program
                  > pgutil packages download --feed=approved-npm --package=@babel/runtime --version=7.25.0 --output-file=C:\npm-packages\package.tgz 
                  > pgutil packages download --feed=public-debian --package= debhelper --version=13.15.3 --component=main --distro=stable --arch=all --output-file=C:\debian-packages\debhelper_13.15.3_all.deb 
 
-                For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-packages/proget-api-packages-download 
+                For more information, see: https://docs.inedo.com/docs/proget/api/packages/download 
                 """;
 
             public static void Configure(ICommandBuilder builder)

--- a/pgutil/Packages/ListCommand.cs
+++ b/pgutil/Packages/ListCommand.cs
@@ -15,7 +15,7 @@ internal partial class Program
                   $> pgutil packages list --package=@babel/runtime --feed=approved-npm
                   $> pgutil packages list --package=Django --version=5.0.6 --feed=private-pypi --stable=true
 
-                For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-packages/proget-api-packages-list
+                For more information, see: https://docs.inedo.com/docs/proget/api/packages/list
                 """;
 
             public static void Configure(ICommandBuilder builder)

--- a/pgutil/Packages/PromoteCommand.cs
+++ b/pgutil/Packages/PromoteCommand.cs
@@ -16,7 +16,7 @@ internal partial class Program
                   $> pgutil packages promote --feed=unapproved-npm --to-feed=approved-npm --package=@babel/runtime --version=7.21.0
                   $> pgutil packages promote --feed=private-pypi --to-feed=public-pypi --package=Django --version=5.0.6 --filename=Django-5.0.6.tar.gz
 
-                For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-packages/proget-api-packages-promote
+                For more information, see: https://docs.inedo.com/docs/proget/api/packages/promote
                 """;
 
             public static void Configure(ICommandBuilder builder)

--- a/pgutil/Packages/RepackageCommand.cs
+++ b/pgutil/Packages/RepackageCommand.cs
@@ -15,7 +15,7 @@ internal partial class Program
                   $> pgutil packages repackage --feed=public-nuget --package=Newtonsoft.Json --version=13.0.3-beta1 --new-version=13.0.3
                   $> pgutil packages repackage --feed=approved-npm --package=@babel/runtime --version=7.21.4-esm.4 --new-version=7.21.5 
 
-                For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-packages/proget-api-packages-repackage
+                For more information, see: https://docs.inedo.com/docs/proget/api/packages/repackage
                 """;
 
             public static void Configure(ICommandBuilder builder)

--- a/pgutil/Packages/StatusCommand.cs
+++ b/pgutil/Packages/StatusCommand.cs
@@ -16,7 +16,7 @@ internal partial class Program
                   $> pgutil packages status deprecated --feed=approved-npm --package=@babel/runtime --version=7.21.0 --state=deprecated --reason=Updated
                   $> pgutil packages status blocked --feed=private-pypi --package=Django --version=5.0.6 --filename=Django-5.0.6.tar.gz --state=allowed
 
-                For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-packages/proget-api-packages-status
+                For more information, see: https://docs.inedo.com/docs/proget/api/packages/status
                 """;
 
             public static void Configure(ICommandBuilder builder)

--- a/pgutil/Packages/UploadCommand.cs
+++ b/pgutil/Packages/UploadCommand.cs
@@ -16,7 +16,7 @@ internal partial class Program
                   $> pgutil packages upload --feed=approved-debian --input-file=C:\projects\project-packages\debhelper_13.15.3_all.deb --distribution=main
                   $> pgutil packages upload --feed=internal-maven --input-file=my-app-1.1.jar --artifactPath=/com/my-company/my-app/1.1
 
-                For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-packages/proget-api-packages-upload
+                For more information, see: https://docs.inedo.com/docs/proget/api/packages/upload
                 """;
 
             public static void Configure(ICommandBuilder builder)

--- a/pgutil/Packages/VersionsCommand.cs
+++ b/pgutil/Packages/VersionsCommand.cs
@@ -15,7 +15,7 @@ internal partial class Program
                   $> pgutil packages versions --package=@babel/runtime --feed=public-npm --stable=true
                   $> pgutil packages versions --package=django --feed=private-pypi
 
-                For more information, see: https://docs.inedo.com/docs/proget/reference-api/proget-api-packages/proget-api-packages-list-versions
+                For more information, see: https://docs.inedo.com/docs/proget/api/packages/list-versions
                 """;
 
             public static void Configure(ICommandBuilder builder)

--- a/pgutil/Upack/CreateCommand.cs
+++ b/pgutil/Upack/CreateCommand.cs
@@ -18,7 +18,7 @@ internal partial class Program
                   $> $ pgutil upack create --name=my-package --version=1.2.3 --source-directory=.\package-files\my-package --target-directory=.\universal-packages
                   $> $ pgutil upack create --manifest=.\package-files\my-package\upack.json --source-directory=.\package-files\my-package --target-directory=.\universal-packages
 
-                For more information, see: https://docs.inedo.com/docs/proget/feeds/universal#upack-create
+                For more information, see: https://docs.inedo.com/docs/proget/api/universal-feed/upload
                 """;
 
             public static void Configure(ICommandBuilder builder)

--- a/pgutil/Upack/ListCommand.cs
+++ b/pgutil/Upack/ListCommand.cs
@@ -11,12 +11,6 @@ internal partial class Program
         {
             public static string Name => "list";
             public static string Description => "List packages in the local registry";
-            public static string Examples => """
-                  $> pgutil upack list
-
-                For more information, see: https://docs.inedo.com/docs/proget/feeds/universal#installing-universal-packages
-                """;
-
             public static void Configure(ICommandBuilder builder)
             {
             }

--- a/pgutil/Upack/RemoveCommand.cs
+++ b/pgutil/Upack/RemoveCommand.cs
@@ -14,7 +14,7 @@ internal partial class Program
             public static string Examples => """
                   $> pgutil upack remove --package=my-package
 
-                For more information, see: https://docs.inedo.com/docs/proget/feeds/universal#installing-universal-packages
+                For more information, see: https://docs.inedo.com/docs/proget/feeds/universal#updating-and-removing-installed-packages
                 """;
 
             public static void Configure(ICommandBuilder builder)

--- a/pgutil/Upack/UpdateCommand.cs
+++ b/pgutil/Upack/UpdateCommand.cs
@@ -14,7 +14,7 @@ internal partial class Program
             public static string Examples => """
                   $> pgutil upack update --package=my-package --version=2.0.1 --feed=universal
 
-                For more information, see: https://docs.inedo.com/docs/proget/feeds/universal#installing-universal-packages
+                For more information, see: https://docs.inedo.com/docs/proget/feeds/universal#updating-and-removing-installed-packages
                 """;
 
             public static void Configure(ICommandBuilder builder)

--- a/pgutil/Vulns/AssessCommand.cs
+++ b/pgutil/Vulns/AssessCommand.cs
@@ -15,7 +15,7 @@ internal sealed partial class VulnsCommand
 
               >$ pgutil vulns assess --id=PGV-0987654 --type=blocked --comment="Package non-compliant" --policy=myPolicy
 
-            For more information, see: https://docs.inedo.com/docs/proget/reference-api/vulnerabilities/proget-api-vulnerabilties-assess
+            For more information, see: https://docs.inedo.com/docs/proget/api/vulnerabilities/assess
             """;
 
         public static void Configure(ICommandBuilder builder)

--- a/pgutil/Vulns/AuditCommand.cs
+++ b/pgutil/Vulns/AuditCommand.cs
@@ -15,7 +15,7 @@ internal sealed partial class VulnsCommand
 
               >$ pgutil vulns audit --project=c:\projects\abc-nuget-project.csproj --type=nuget
 
-            For more information, see: https://docs.inedo.com/docs/proget/reference-api/vulnerabilities/proget-api-vulnerabilties-audit
+            For more information, see: https://docs.inedo.com/docs/proget/api/vulnerabilities/audit
             """;
 
         public static void Configure(ICommandBuilder builder)


### PR DESCRIPTION
- Updated all the api URLs
- Fixed some "typos" where the example was for the wrong command (e.g. a "create" command would list a "remove" example or something
- Moved some examples around due to an issue where examples for builds projects create was listed under builds create,  and builds create was listed under builds
