### PR TITLE
Fix cross-platform path resolution in NuGetDependencyScanner

### DIFF
--- a/Inedo.ProGet/Scan/NuGetDependencyScanner.cs
+++ b/Inedo.ProGet/Scan/NuGetDependencyScanner.cs
@@ -24,7 +24,9 @@ internal sealed partial class NuGetDependencyScanner(CreateDependencyScannerArgs
 
             await foreach (var p in ReadFoldersAndProjectsFromSolutionAsync(this.SourcePath, cancellationToken).ConfigureAwait(false))
             {
-                var projectPath = Path.GetFullPath(Path.Combine(solutionRoot, p));
+                var normalizedPath = p.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
+                var projectPath = Path.GetFullPath(this.FileSystem.Combine(solutionRoot, normalizedPath));
+
                 IAsyncEnumerable<DependencyPackage> packages;
 
                 if (assets.TryGetValue(projectPath, out var a))

--- a/Inedo.ProGet/Scan/NuGetDependencyScanner.cs
+++ b/Inedo.ProGet/Scan/NuGetDependencyScanner.cs
@@ -24,7 +24,7 @@ internal sealed partial class NuGetDependencyScanner(CreateDependencyScannerArgs
 
             await foreach (var p in ReadFoldersAndProjectsFromSolutionAsync(this.SourcePath, cancellationToken).ConfigureAwait(false))
             {
-                var projectPath = this.FileSystem.Combine(solutionRoot, p);
+                var projectPath = Path.GetFullPath(Path.Combine(solutionRoot, p));
                 IAsyncEnumerable<DependencyPackage> packages;
 
                 if (assets.TryGetValue(projectPath, out var a))


### PR DESCRIPTION
Use Path.GetFullPath() to normalize project paths when combining solution root 
with relative project paths. This resolves issues where solution files created 
on Windows contain Windows-style path separators that cause path resolution 
failures when pgutil is executed on macOS/Linux systems.

The change ensures proper path normalization across all platforms by leveraging 
.NET's built-in path handling instead of relying on FileSystem.Combine alone.